### PR TITLE
10 add llm as judge metric

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,11 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
+outputs/
+scripts/
+.vscode/
+*.json
+data
+dpo_data
+cli/wandb
+*.wav

--- a/cli/eval.py
+++ b/cli/eval.py
@@ -106,9 +106,9 @@ def main(cfg: DictConfig):
                                                                caption=f'generated_{i}', sample_rate=tokeniser.fe_sample_rate)
                 logs[f'prompt/prompt_{i}'] = wandb.Audio(prompt.squeeze(0).cpu().numpy(),
                                                          caption=f'prompt_{i}', sample_rate=tokeniser.fe_sample_rate)
-                if "text_res" in res:
-                    logs[f'prompt/prompt_text_{i}'] = res["text_res"][i][0]
-                    logs[f'generated/generated_text_{i}'] = res["text_res"][i][1]
+                if "audio_transcription" in res:
+                    logs[f'prompt/prompt_text_{i}'] = res["audio_transcription"][i][0]
+                    logs[f'generated/generated_text_{i}'] = res["audio_transcription"][i][1]
                     
             wandb.log(logs)
         for key, val in res.items():

--- a/cli/eval.py
+++ b/cli/eval.py
@@ -5,7 +5,7 @@ import hydra
 from slamkit.vocoder import vocoder_factory
 from slamkit.model import tlm_factory
 from slamkit.tokeniser import tokeniser_factory
-from slamkit.metric.generative_metric import generate, asr_perplexity
+from slamkit.metric.generative_metric import generate, asr_perplexity, llm_as_judge
 from slamkit.metric.modelling_metric import swuggy, salmon, sblimp, storycloze
 from slamkit.model import SpeechLM
 import torch
@@ -47,12 +47,19 @@ def main(cfg: DictConfig):
                 if cfg.vocoder is None:
                     logger.warning("You are currently trying to run generation without a vocoder, which will generate tokens, but has no effect. You can use a vocoder by, e.g. setting `vocoder=vocoder_hubert_25`")
                 res = generate(model, path, cfg.batch_size, used_token_modality,
-                            cfg.metric.prompt_length, tokeniser.fe_sample_rate, cfg.metric.num_files,
+                            cfg.metric.prompt_length, cfg.metric.get("min_file_length",None), cfg.metric.get("alignment_folder", None), cfg.metric.get("use_alignment", False),
+                            tokeniser.fe_sample_rate, cfg.metric.num_files,
                             cfg.num_workers, cfg.pin_memory, **cfg.metric.get("generate_kwargs", {}))
             elif cfg.metric.metric_type == 'asr_perplexity':
                 res = asr_perplexity(model, path, cfg.batch_size, cfg.metric.whisper_model, cfg.metric.llm_name_or_path, used_token_modality,
-                                    cfg.metric.prompt_length, cfg.metric.auto_bleu_n, tokeniser.fe_sample_rate, cfg.metric.get("num_files", None),
+                                    cfg.metric.prompt_length, cfg.metric.get("min_file_length",None), cfg.metric.get("alignment_folder", None), cfg.metric.get("use_alignment", False),
+                                    cfg.metric.auto_bleu_n, tokeniser.fe_sample_rate, cfg.metric.get("num_files", None),
                                     cfg.num_workers, cfg.pin_memory, **cfg.metric.get("generate_kwargs", {}))
+            elif cfg.metric.metric_type == 'llm_as_judge':
+                res = llm_as_judge(model, path, cfg.batch_size, cfg.metric.whisper_model, cfg.metric.llm_name_or_path, cfg.metric.instruction, used_token_modality,
+                                   cfg.metric.prompt_length, cfg.metric.min_file_length, cfg.metric.get("alignment_folder", None), cfg.metric.get("use_alignment", False),
+                                   tokeniser.fe_sample_rate, cfg.metric.get("num_files", None),
+                                   cfg.num_workers, cfg.pin_memory, **cfg.metric.get("generate_kwargs", {}))
             else:
                 raise ValueError(f'Unknown metric type: {cfg.metric.metric_type}')
         else:
@@ -64,7 +71,12 @@ def main(cfg: DictConfig):
         for key, val in res.items():
             if key == "generate" or key == "prompts":
                 continue
-            print(f"{key}: {val}")
+            if isinstance(val, list):
+                print(f"{key}:")
+                for i, v in enumerate(val):
+                    print(f"\t{i}: {v}")
+            else: 
+                print(f"{key}: {val}")
     if cfg.metric.get("out_path", False) and "generate" in res and cfg.vocoder is not None:
         import torchaudio
         os.makedirs(cfg.metric.out_path, exist_ok=True)
@@ -94,6 +106,10 @@ def main(cfg: DictConfig):
                                                                caption=f'generated_{i}', sample_rate=tokeniser.fe_sample_rate)
                 logs[f'prompt/prompt_{i}'] = wandb.Audio(prompt.squeeze(0).cpu().numpy(),
                                                          caption=f'prompt_{i}', sample_rate=tokeniser.fe_sample_rate)
+                if "text_res" in res:
+                    logs[f'prompt/prompt_text_{i}'] = res["text_res"][i][0]
+                    logs[f'generated/generated_text_{i}'] = res["text_res"][i][1]
+                    
             wandb.log(logs)
         for key, val in res.items():
             if key == "generate" or key == "prompts":

--- a/config/metric/asr_perplexity.yaml
+++ b/config/metric/asr_perplexity.yaml
@@ -14,4 +14,3 @@ generate_kwargs:
   top_k: 25
   max_new_tokens: 150
   do_sample: true
-  repetition_penalty: 1.1 # To help with repetitions in post-DPO models as mentioned in the paper

--- a/config/metric/asr_perplexity.yaml
+++ b/config/metric/asr_perplexity.yaml
@@ -14,4 +14,4 @@ generate_kwargs:
   top_k: 25
   max_new_tokens: 150
   do_sample: true
-  repetition_penalty: 1.1
+  repetition_penalty: 1.1 # To help with repetitions in post-DPO models as mentioned in the paper

--- a/config/metric/asr_perplexity.yaml
+++ b/config/metric/asr_perplexity.yaml
@@ -14,3 +14,4 @@ generate_kwargs:
   top_k: 25
   max_new_tokens: 150
   do_sample: true
+  repetition_penalty: 1.1

--- a/config/metric/generate.yaml
+++ b/config/metric/generate.yaml
@@ -10,6 +10,5 @@ ext: wav
 generate_kwargs:
   temperature: 0.8
   top_k: 25
-  repetition_penalty: 1.1  # To help with repetitions in post-DPO models as mentioned in the paper
   max_new_tokens: 150
   do_sample: true

--- a/config/metric/llm_as_judge.yaml
+++ b/config/metric/llm_as_judge.yaml
@@ -1,0 +1,20 @@
+defaults:
+  - default
+  - _self_
+
+metric_type: llm_as_judge
+whisper_model: openai/whisper-large-v3-turbo
+llm_name_or_path: gpt-4o
+instruction: "The task is evaluating the relevance and likelihood of the predicted text continuation, given the text prompt. You should also consider whether the meaning of the text continuation is making sense. The text prompt is: \"[prompt_audio_transcription]\", and the text continuation is :\"[generated_audio_transcription]\". You must give an overall rating from 1 to 5. The rating guideline is as below:\n1: The text continuation is very unlikely and irrelevant to the text prompt.\n2: The text continuation is unlikely and marginally relevant to the text prompt.\n3: The text continuation is moderately likely and relevant to the text prompt.\n4: The text continuation is likely and relevant to the text prompt.\n5: The text continuation is very likely and highly relevant.\n You should take the following steps to provide the score:\nFirst: briefly analyze the sample with the above definition.\nSecond: MUST follow the output format as: \"The final answer is $\\boxed{x}$\". Where x is the score you are giving."
+prompt_length: 3
+num_files: null
+min_file_length: 6
+use_alignment: true
+alignment_folder: null                
+num_log: 10
+generate_kwargs:
+  temperature: 0.8
+  top_k: 25
+  max_new_tokens: 150
+  do_sample: true
+  repetition_penalty: 1.1

--- a/config/metric/llm_as_judge.yaml
+++ b/config/metric/llm_as_judge.yaml
@@ -17,4 +17,4 @@ generate_kwargs:
   top_k: 25
   max_new_tokens: 150
   do_sample: true
-  repetition_penalty: 1.1
+  repetition_penalty: 1.1 # To help with repetitions in post-DPO models as mentioned in the paper

--- a/config/metric/llm_as_judge.yaml
+++ b/config/metric/llm_as_judge.yaml
@@ -17,4 +17,3 @@ generate_kwargs:
   top_k: 25
   max_new_tokens: 150
   do_sample: true
-  repetition_penalty: 1.1 # To help with repetitions in post-DPO models as mentioned in the paper

--- a/slamkit/metric/generative_metric.py
+++ b/slamkit/metric/generative_metric.py
@@ -156,7 +156,7 @@ def llm_as_judge(model: SpeechLM, data_path: str, batch_size: int, whisper_model
         prompts.extend(audio)
         prompt_audio_transcriptions = whisper_pipeline([sample.cpu().numpy() for sample in audio], batch_size=len(audio))
         generated_audio_transcriptions = whisper_pipeline([gen.cpu().numpy() for gen in gen_res], batch_size=len(gen_res))
-        prompt_audio_transcriptions = [res_text["text"] if audio.shape[-1] > 0 else "" for audio, res_text in zip(audio, prompt_audio_transcriptions)]
+        prompt_audio_transcriptions = [res_text["text"] if smaple.shape[-1] > 0 else "" for smaple, res_text in zip(audio, prompt_audio_transcriptions)]
         generated_audio_transcriptions = [res_text["text"] if gen.shape[-1] > 0 else "" for gen, res_text in zip(gen_res, generated_audio_transcriptions)]
         text = [
             instruction.replace("[prompt_audio_transcription]", prompt_audio_transcription).replace("[generated_audio_transcription]", generated_audio_transcription) for 
@@ -168,5 +168,5 @@ def llm_as_judge(model: SpeechLM, data_path: str, batch_size: int, whisper_model
     res = judge(texts)
     res = list(filter(lambda x: x is not None, res))
     text_res = [(p_text,g_text) for p_text, g_text, r in zip(prompt_texts, gen_texts, res)]
-    print("got response for {} out of {}".format(len(res), len(dataset)))
+    logger.info("got response for {} out of {}".format(len(res), len(dataset)))
     return {'llm_as_judge': torch.as_tensor(res).float().mean().item(), "generate": gen, "prompts": prompts, "text_res": text_res}

--- a/slamkit/metric/generative_metric.py
+++ b/slamkit/metric/generative_metric.py
@@ -141,7 +141,7 @@ def llm_as_judge(model: SpeechLM, data_path: str, batch_size: int, whisper_model
                             alignment_folder=alignment_folder, use_alignment=use_alignment)
     assert len(dataset) > 0, f"no samples found for {data_path}"
     assert instruction is not None, "llm_as_judge requires instruction"
-    assert "[prompt_audio_transcription]" in instruction, "llm_as_judge requires [text_prompt] in instruction"
+    assert "[prompt_audio_transcription]" in instruction, "llm_as_judge requires [prompt_audio_transcription] in instruction"
     assert "[generated_audio_transcription]" in instruction, "llm_as_judge requires [generated_audio_transcription] in instruction"
     dl = DataLoader(dataset, batch_size=batch_size, collate_fn=pad_collate,
                     num_workers=num_workers, pin_memory=pin_memory)
@@ -154,7 +154,7 @@ def llm_as_judge(model: SpeechLM, data_path: str, batch_size: int, whisper_model
         gen_res = model.generate(audio, l, used_tokens_modality, remove_prompt=True, **generate_kwargs)
         gen.extend(gen_res)
         prompts.extend(audio)
-        prompt_audio_transcriptions = whisper_pipeline([audio.cpu().numpy() for audio in audio], batch_size=len(audio))
+        prompt_audio_transcriptions = whisper_pipeline([sample.cpu().numpy() for sample in audio], batch_size=len(audio))
         generated_audio_transcriptions = whisper_pipeline([gen.cpu().numpy() for gen in gen_res], batch_size=len(gen_res))
         prompt_audio_transcriptions = [res_text["text"] if audio.shape[-1] > 0 else "" for audio, res_text in zip(audio, prompt_audio_transcriptions)]
         generated_audio_transcriptions = [res_text["text"] if gen.shape[-1] > 0 else "" for gen, res_text in zip(gen_res, generated_audio_transcriptions)]

--- a/slamkit/metric/generative_metric.py
+++ b/slamkit/metric/generative_metric.py
@@ -156,7 +156,7 @@ def llm_as_judge(model: SpeechLM, data_path: str, batch_size: int, whisper_model
         prompts.extend(audio)
         prompt_audio_transcriptions = whisper_pipeline([sample.cpu().numpy() for sample in audio], batch_size=len(audio))
         generated_audio_transcriptions = whisper_pipeline([gen.cpu().numpy() for gen in gen_res], batch_size=len(gen_res))
-        prompt_audio_transcriptions = [res_text["text"] if smaple.shape[-1] > 0 else "" for smaple, res_text in zip(audio, prompt_audio_transcriptions)]
+        prompt_audio_transcriptions = [res_text["text"] if sample.shape[-1] > 0 else "" for sample, res_text in zip(audio, prompt_audio_transcriptions)]
         generated_audio_transcriptions = [res_text["text"] if gen.shape[-1] > 0 else "" for gen, res_text in zip(gen_res, generated_audio_transcriptions)]
         text = [
             instruction.replace("[prompt_audio_transcription]", prompt_audio_transcription).replace("[generated_audio_transcription]", generated_audio_transcription) for 

--- a/slamkit/metric/generative_metric.py
+++ b/slamkit/metric/generative_metric.py
@@ -1,3 +1,4 @@
+import json
 import torchaudio
 import torch
 from tqdm import tqdm
@@ -6,24 +7,49 @@ from torch.nn.utils.rnn import pad_sequence
 from glob import glob, iglob
 import logging
 from typing import Optional
+import os
 
-from .metric_utils import get_whisper_pipeline, get_llm, get_llm_preplexity
+from .metric_utils import get_whisper_pipeline, get_llm, get_llm_preplexity, get_judge
 from ..model.speech_lm import SpeechLM
 from ..utils.calculation_utils import calc_auto_bleu
 
 logger = logging.getLogger(__name__)
 
+def get_cut_location(alignment, prompt_length):
+    """
+    Find the closest word in the alignment to the prompt length.
+    """
+    endtimes = torch.tensor([word[2] for word in alignment])
+    dist = torch.abs(endtimes - prompt_length)
+    time = endtimes[dist.argmin()].item()        
+    return time
 
+def is_shorter(file, min_file_length):
+    metadata = torchaudio.info(file)
+    if metadata.num_frames < min_file_length * metadata.sample_rate:
+        return True
+    return False
 
 class PromptDataset(Dataset):
-    def __init__(self, glob_path, prompt_length=None, sample_rate=16000, num_files=None):
+    def __init__(self, glob_path, prompt_length=None, sample_rate=16000, num_files=None, min_file_length=None, use_alignment=False, alignment_folder=None):
         self.prompt_length = prompt_length
         self.sample_rate = sample_rate
         if num_files is None:
             self.data = glob(glob_path, recursive=True)
+            if min_file_length is not None:
+                self.data = list(filter(lambda x: not is_shorter(x, min_file_length), self.data))
         else:
+            self.data = []
             paths = iglob(glob_path, recursive=True)
-            self.data = [next(paths) for _ in range(num_files)]
+            for path in paths:
+                if len(self.data) >= num_files:
+                    break
+                if min_file_length is not None:
+                    if is_shorter(path, min_file_length):
+                        continue
+                self.data.append(path)
+        self.use_alignment = use_alignment
+        self.alignment_folder = alignment_folder
 
     def __len__(self):
         return len(self.data)
@@ -33,10 +59,25 @@ class PromptDataset(Dataset):
         audio, sr = torchaudio.load(file)
         if sr != self.sample_rate:
             audio = torchaudio.functional.resample(audio, sr, self.sample_rate)
-        audio = audio.squeeze(0)
-        if self.prompt_length is not None:
+        if audio.ndim == 2:
+            audio = audio.mean(dim=0)
+        if self.prompt_length is not None and not self.use_alignment:
             audio = audio[:int(self.prompt_length*self.sample_rate)]
+        elif self.prompt_length is not None and self.use_alignment:
+            alignment_path = self.get_alignment_path(file)
+            with open(alignment_path, 'r') as f:
+                meta = json.load(f)
+                alignment = meta['aligned_text']
+            prompt_length = get_cut_location(alignment, self.prompt_length)
+            audio = audio[:int(prompt_length*self.sample_rate)]
         return audio, audio.shape[-1]
+    
+    def get_alignment_path(self, file):
+        if self.alignment_folder is None:
+            return file.replace(".wav", ".json")
+        basename = os.path.basename(file)
+        alignment_path = os.path.join(self.alignment_folder, basename[:basename.find(".")] + ".json")
+        return alignment_path
 
 def pad_collate(batch):
     audio, l = zip(*batch)
@@ -44,11 +85,13 @@ def pad_collate(batch):
     return audio, torch.tensor(l)
 
 
-def generate(model: SpeechLM, data_path: str, batch_size: int, used_tokens_modality:Optional[str] = None, prompt_length: Optional[int] = None, sample_rate: int = 16000,
+def generate(model: SpeechLM, data_path: str, batch_size: int, used_tokens_modality:Optional[str] = None, prompt_length: Optional[int] = None, 
+             min_file_length: Optional[int] = None, alignment_folder: Optional[str] = None, use_alignment: bool = False, sample_rate: int = 16000,
              num_files: Optional[int] = None, num_workers: int = 8,
              pin_memory: bool = True, **generate_kwargs):
     dataset = PromptDataset(data_path, prompt_length=prompt_length,
-                            sample_rate=sample_rate, num_files=num_files)
+                            sample_rate=sample_rate, num_files=num_files, min_file_length=min_file_length, 
+                            alignment_folder=alignment_folder, use_alignment=use_alignment)
     assert len(dataset) > 0, f"no samples found for {data_path}"
     dl = DataLoader(dataset, batch_size=batch_size, collate_fn=pad_collate,
                     num_workers=num_workers, pin_memory=pin_memory)
@@ -62,12 +105,14 @@ def generate(model: SpeechLM, data_path: str, batch_size: int, used_tokens_modal
     return {'generate': res, "prompts": prompts}
         
 def asr_perplexity(model: SpeechLM, data_path: str, batch_size: int, whisper_model: str, llm_name_or_path: str, used_tokens_modality:Optional[str] = None,
-                   prompt_length: Optional[int] = None, auto_bleu_n: int = 2,
+                   prompt_length: Optional[int] = None, min_file_length: Optional[int] = None, alignment_folder: Optional[str] = None, use_alignment: bool = False,
+                   auto_bleu_n: int = 2,
                    sample_rate: int = 16000, num_files: Optional[int] = None , num_workers: int = 8, pin_memory: bool = True, **generate_kwargs): 
     from nltk.tokenize import NLTKWordTokenizer
     nltk_word_tokenizer = NLTKWordTokenizer()
 
-    dataset = PromptDataset(data_path, num_files=num_files, prompt_length=prompt_length, sample_rate=sample_rate)
+    dataset = PromptDataset(data_path, num_files=num_files, prompt_length=prompt_length, sample_rate=sample_rate, min_file_length=min_file_length, 
+                            alignment_folder=alignment_folder, use_alignment=use_alignment)
     assert len(dataset) > 0, f"no samples found for {data_path}"
     dl = DataLoader(dataset, batch_size=batch_size, collate_fn=pad_collate,
                     num_workers=num_workers, pin_memory=pin_memory)
@@ -87,3 +132,41 @@ def asr_perplexity(model: SpeechLM, data_path: str, batch_size: int, whisper_mod
     return {'asr_perplexity': torch.stack(nlls).mean().exp().item(),
             f"auto-belu-{auto_bleu_n}": torch.as_tensor(bleus).mean().item(), 
             "generate": gen, "prompts": prompts}
+
+def llm_as_judge(model: SpeechLM, data_path: str, batch_size: int, whisper_model: str, llm_name_or_path:str, instruction:str, used_tokens_modality:Optional[str] = None,
+                 prompt_length: Optional[int] = None, min_file_length: Optional[int] = None, alignment_folder: Optional[str] = None, use_alignment: bool = False,
+                 sample_rate: int = 16000, num_files: Optional[int] = None , num_workers: int = 8, pin_memory: bool = True, **generate_kwargs):
+    
+    dataset = PromptDataset(data_path, num_files=num_files, prompt_length=prompt_length, sample_rate=sample_rate, min_file_length=min_file_length, 
+                            alignment_folder=alignment_folder, use_alignment=use_alignment)
+    assert len(dataset) > 0, f"no samples found for {data_path}"
+    assert instruction is not None, "llm_as_judge requires instruction"
+    assert "[prompt_audio_transcription]" in instruction, "llm_as_judge requires [text_prompt] in instruction"
+    assert "[generated_audio_transcription]" in instruction, "llm_as_judge requires [generated_audio_transcription] in instruction"
+    dl = DataLoader(dataset, batch_size=batch_size, collate_fn=pad_collate,
+                    num_workers=num_workers, pin_memory=pin_memory)
+    whisper_pipeline = get_whisper_pipeline(whisper_model, device=model.device)
+    judge = get_judge(llm_name_or_path, device=model.device, batch_size=batch_size)
+    res, gen, prompts, texts = [], [], [], []
+    prompt_texts, gen_texts = [], []
+    for audio, l in tqdm(dl, desc="Generating"):
+        audio = audio.to(model.device)
+        gen_res = model.generate(audio, l, used_tokens_modality, remove_prompt=True, **generate_kwargs)
+        gen.extend(gen_res)
+        prompts.extend(audio)
+        prompt_audio_transcriptions = whisper_pipeline([audio.cpu().numpy() for audio in audio], batch_size=len(audio))
+        generated_audio_transcriptions = whisper_pipeline([gen.cpu().numpy() for gen in gen_res], batch_size=len(gen_res))
+        prompt_audio_transcriptions = [res_text["text"] if audio.shape[-1] > 0 else "" for audio, res_text in zip(audio, prompt_audio_transcriptions)]
+        generated_audio_transcriptions = [res_text["text"] if gen.shape[-1] > 0 else "" for gen, res_text in zip(gen_res, generated_audio_transcriptions)]
+        text = [
+            instruction.replace("[prompt_audio_transcription]", prompt_audio_transcription).replace("[generated_audio_transcription]", generated_audio_transcription) for 
+            prompt_audio_transcription, generated_audio_transcription in zip(prompt_audio_transcriptions, generated_audio_transcriptions)
+        ]
+        texts.extend(text)
+        prompt_texts.extend(prompt_audio_transcriptions)
+        gen_texts.extend(generated_audio_transcriptions)
+    res = judge(texts)
+    res = list(filter(lambda x: x is not None, res))
+    text_res = [(p_text,g_text) for p_text, g_text, r in zip(prompt_texts, gen_texts, res)]
+    print("got response for {} out of {}".format(len(res), len(dataset)))
+    return {'llm_as_judge': torch.as_tensor(res).float().mean().item(), "generate": gen, "prompts": prompts, "text_res": text_res}

--- a/slamkit/metric/generative_metric.py
+++ b/slamkit/metric/generative_metric.py
@@ -15,9 +15,9 @@ from ..utils.calculation_utils import calc_auto_bleu
 
 logger = logging.getLogger(__name__)
 
-def get_cut_location(alignment:List[Tuple[str,float,float]], prompt_length:float):
+def get_cut_location(alignment: List[Tuple[str,float,float]], prompt_length:float):
     """
-    alignmet is a list of tuples (word, start_time, end_time)
+    alignmet is a list of tuples (word, start_time, end_time), time is in seconds.
     Find the closest word in the alignment to the prompt length. returns it's end time.
     """
     endtimes = torch.tensor([word[2] for word in alignment])

--- a/slamkit/metric/metric_utils.py
+++ b/slamkit/metric/metric_utils.py
@@ -86,7 +86,7 @@ class LLMJudge:
         self.device = device
         self.batch_size = batch_size
 
-    def __call__(self, texts:List[str]):
+    def __call__(self, texts:List[str]) -> List[int]:
         res = []
         for i in tqdm(range(0, len(texts), self.batch_size), desc="LLM Judging"):
             batch_text = texts[i:i + self.batch_size]
@@ -103,7 +103,7 @@ class OpenAIJudge:
         self.model_name = name
         
 
-    def __call__(self, texts:List[str]):
+    def __call__(self, texts:List[str]) -> List[int]:
         res = []
         for text in tqdm(texts, desc="OpenAI Judging"):
             try:

--- a/slamkit/metric/metric_utils.py
+++ b/slamkit/metric/metric_utils.py
@@ -65,10 +65,9 @@ def extract_digit_from_boxed(string):
         return int(match.group(1))
     return None
 
-def judge_text(model, tokenizer, text:List[str], device):
-    
-    tokenizer.padding_side = "left"
-    model_inputs = tokenizer(text, return_tensors='pt', padding=True).to(device)
+def judge_text(model, tokeniser, text:List[str], device):
+    tokeniser.padding_side = "left"
+    model_inputs = tokeniser(text, return_tensors='pt', padding=True).to(device)
     generation = model.generate(
         input_ids=model_inputs['input_ids'],
         attention_mask=model_inputs['attention_mask'],
@@ -76,14 +75,14 @@ def judge_text(model, tokenizer, text:List[str], device):
         do_sample=True,
         temperature=0.8,
     )
-    decode = tokenizer.batch_decode(generation, skip_special_tokens=True)
+    decode = tokeniser.batch_decode(generation, skip_special_tokens=True)
     res = [extract_digit_from_boxed(text) for text in decode]
     return res
 
 class LLMJudge:
-    def __init__(self, model, tokenizer, device, batch_size):
+    def __init__(self, model, tokeniser, device, batch_size):
         self.model = model
-        self.tokenizer = tokenizer
+        self.tokeniser = tokeniser
         self.device = device
         self.batch_size = batch_size
 
@@ -91,7 +90,7 @@ class LLMJudge:
         res = []
         for i in tqdm(range(0, len(texts), self.batch_size), desc="LLM Judging"):
             batch_text = texts[i:i + self.batch_size]
-            res.extend(judge_text(self.model, self.tokenizer, batch_text, self.device))
+            res.extend(judge_text(self.model, self.tokeniser, batch_text, self.device))
         return res
     
 
@@ -126,5 +125,5 @@ def get_judge(name, device, batch_size):
     if name in OPENAI_MODELS:
         return OpenAIJudge(name)
     else:
-        model, tokenizer = get_llm(name, device)
-        return LLMJudge(model, tokenizer, device, batch_size)
+        model, tokeniser = get_llm(name, device)
+        return LLMJudge(model, tokeniser, device, batch_size)

--- a/slamkit/metric/metric_utils.py
+++ b/slamkit/metric/metric_utils.py
@@ -87,10 +87,10 @@ class LLMJudge:
         self.device = device
         self.batch_size = batch_size
 
-    def __call__(self, text:List[str]):
+    def __call__(self, texts:List[str]):
         res = []
-        for i in tqdm(range(0, len(text), self.batch_size), desc="LLM Judging"):
-            batch_text = text[i:i + self.batch_size]
+        for i in tqdm(range(0, len(texts), self.batch_size), desc="LLM Judging"):
+            batch_text = texts[i:i + self.batch_size]
             res.extend(judge_text(self.model, self.tokenizer, batch_text, self.device))
         return res
     
@@ -104,9 +104,9 @@ class OpenAIJudge:
         self.model_name = name
         
 
-    def __call__(self, text:List[str]):
+    def __call__(self, texts:List[str]):
         res = []
-        for text in tqdm(text, desc="OpenAI Judging"):
+        for text in tqdm(texts, desc="OpenAI Judging"):
             try:
                 completion = self.client.chat.completions.create(
                     model=self.model_name,

--- a/slamkit/metric/metric_utils.py
+++ b/slamkit/metric/metric_utils.py
@@ -2,8 +2,17 @@
 from typing import List
 import torch
 from transformers import AutoModelForSpeechSeq2Seq, AutoProcessor, pipeline, AutoTokenizer, AutoModelForCausalLM, PreTrainedModel, PreTrainedTokenizer
-
+import re
 from ..utils.calculation_utils import calc_nll
+from tqdm import tqdm
+import os
+
+
+OPENAI_MODELS = [
+    "gpt-3.5-turbo",
+    "gpt-4",
+    "gpt-4o"
+]
 
 
 def get_whisper_pipeline(model_id, device):
@@ -47,3 +56,73 @@ def get_llm_preplexity(model:PreTrainedModel, tokeniser:PreTrainedTokenizer, tex
     shift_logits = logits[..., :-1, :].contiguous()
     shift_labels = labels[..., 1:].contiguous()
     return calc_nll(shift_logits, shift_labels, shift_labels.ne(-100))
+
+def extract_digit_from_boxed(string):
+    match = re.search(r'\\boxed\{(\d+)\}', string)
+    if match:
+        return int(match.group(1))
+    return None
+
+def judge_text(model, tokenizer, text:List[str], device):
+    
+    tokenizer.padding_side = "left"
+    model_inputs = tokenizer(text, return_tensors='pt', padding=True).to(device)
+    generation = model.generate(
+        input_ids=model_inputs['input_ids'],
+        attention_mask=model_inputs['attention_mask'],
+        max_new_tokens=512,
+        do_sample=True,
+        temperature=0.8,
+    )
+    decode = tokenizer.batch_decode(generation, skip_special_tokens=True)
+    res = [extract_digit_from_boxed(text) for text in decode]
+    return res
+
+class LLMJudge:
+    def __init__(self, model, tokenizer, device, batch_size):
+        self.model = model
+        self.tokenizer = tokenizer
+        self.device = device
+        self.batch_size = batch_size
+
+    def __call__(self, text:List[str]):
+        res = []
+        for i in tqdm(range(0, len(text), self.batch_size), desc="LLM Judging"):
+            batch_text = text[i:i + self.batch_size]
+            res.extend(judge_text(self.model, self.tokenizer, batch_text, self.device))
+        return res
+    
+
+class OpenAIJudge:
+    def __init__(self, name):
+        from openai import OpenAI
+        self.client = OpenAI(
+            api_key=os.environ["OPENAI_API_KEY"],
+        )
+        self.model_name = name
+        
+
+    def __call__(self, text:List[str]):
+        res = []
+        for text in tqdm(text, desc="OpenAI Judging"):
+            try:
+                completion = self.client.chat.completions.create(
+                    model=self.model_name,
+                    messages=[
+                        {"role": "user", "content": text}
+                    ],
+                )
+            except Exception as e:
+                print(f"Error: {e}")
+                continue
+            answer = completion.choices[0].message.content
+            res.append(extract_digit_from_boxed(answer))
+        return res 
+
+        
+def get_judge(name, device, batch_size):
+    if name in OPENAI_MODELS:
+        return OpenAIJudge(name)
+    else:
+        model, tokenizer = get_llm(name, device)
+        return LLMJudge(model, tokenizer, device, batch_size)

--- a/slamkit/metric/metric_utils.py
+++ b/slamkit/metric/metric_utils.py
@@ -1,4 +1,3 @@
-
 from typing import List
 import torch
 from transformers import AutoModelForSpeechSeq2Seq, AutoProcessor, pipeline, AutoTokenizer, AutoModelForCausalLM, PreTrainedModel, PreTrainedTokenizer
@@ -6,6 +5,9 @@ import re
 from ..utils.calculation_utils import calc_nll
 from tqdm import tqdm
 import os
+
+import logging
+logger = logging.getLogger(__name__)
 
 
 OPENAI_MODELS = [
@@ -113,7 +115,7 @@ class OpenAIJudge:
                     ],
                 )
             except Exception as e:
-                print(f"Error: {e}")
+                logger.error(f"Error: {e}")
                 continue
             answer = completion.choices[0].message.content
             res.append(extract_digit_from_boxed(answer))


### PR DESCRIPTION
Adds llm as judge metric to the library.
Use `metric=llm_as_judge`
As the judge you can use either an llm from hf or an openAI model using thier api.
If using openai api set env variable `OPENAI_API_KEY` to the key for open ai api.
also add option to filter prompts shorter than `min_file_length`
add option to use text alignment to cut the prompt so it doesn't cut a word. use `use_alignment=true` and if you're alignment is in a different folder use `alignment_folder=<>`